### PR TITLE
fix: bump Node.js to 22 in publish and CI workflows

### DIFF
--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -12,11 +12,11 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Node.js 20 for workflow
+      - name: Set up Node.js 22 for workflow
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - run: echo "Workflow running on Node.js 20"
+          node-version: 22
+      - run: echo "Workflow running on Node.js 22"
 
   build:
     needs: setup

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
 # See below for current versions supported by Node-red
 # https://nodered.org/docs/faq/node-versions#installing-nodejs
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary
- Bumps `node-version` from 20 → 22 in `npm-publish.yml` — semantic-release v25 requires `^22.14.0 || >=24.10.0`, causing the publish job to fail on Node 20
- Updates the `setup` job echo in `npm-ci.yml` to stay consistent

## Root cause
After upgrading `semantic-release` to v25 in #398, the NPM-Publish workflow kept using Node 20, which is below the new minimum engine requirement.

## Test plan
- [x] NPM-Publish should complete the `npx semantic-release` step without engine errors
- [x] NPM-CI matrix (18.x / 20.x / 22.x) is unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)