### PR TITLE
fix: switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,20 +9,20 @@ on:
 
 jobs:
   publish-npm:
-#    if: ${{github.GITHUB_REF == 'refs/heads/master'}}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # semantic-release: create releases and push tags
+      id-token: write   # npm trusted publisher: OIDC token for npm auth
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-# See below for current versions supported by Node-red
-# https://nodered.org/docs/faq/node-versions#installing-nodejs
+          # https://nodered.org/docs/faq/node-versions#installing-nodejs
           node-version: 22
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm test
       - run: npx semantic-release
         env:
-#          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary
- Removes the `NPM_TOKEN` secret — no more long-lived token to expire
- Adds `id-token: write` permission so GitHub Actions can mint an OIDC token for npm authentication
- Sets `NPM_CONFIG_PROVENANCE=true` so published packages include a signed provenance attestation linking the package back to this repo and workflow run

## Prerequisites
- npm trusted publisher must be configured on npmjs.org for this repo (already done)
- `NPM_TOKEN` secret can be removed from the GitHub repo settings after merging

## Test plan
- [ ] Merge and verify the next push to `master` publishes successfully without `NPM_TOKEN`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)