### PR TITLE
fix: remove registry-url to unblock npm OIDC trusted publisher

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,6 @@ jobs:
         with:
           # https://nodered.org/docs/faq/node-versions#installing-nodejs
           node-version: 22
-          registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm test
       - run: npx semantic-release


### PR DESCRIPTION
## Root cause
`actions/setup-node` with `registry-url` writes a `.npmrc` containing:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```
This overrides the OIDC token that `@semantic-release/npm` fetched — npm then falls back to the (empty) `NODE_AUTH_TOKEN` and fails with `ENEEDAUTH`.

## Fix
Remove `registry-url` from `actions/setup-node`. `@semantic-release/npm` handles npm authentication entirely on its own via the OIDC exchange (confirmed working — the logs showed "OIDC token exchange with the npm registry succeeded").

## Test plan
- [ ] Merge and verify the next push to `master` publishes without `ENEEDAUTH`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)