### PR TITLE
fix: upgrade npm to 11.x for native OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           # https://nodered.org/docs/faq/node-versions#installing-nodejs
           node-version: 22
+      # Node 22 bundles npm 10.x; native OIDC trusted-publisher
+      # support requires npm >= 11.5.1
+      - run: npm install -g npm@latest
       - run: npm ci
       - run: npm test
       - run: npx semantic-release


### PR DESCRIPTION
## Root cause
The previous fixes were on the right track — the logs confirm:
```
[@semantic-release/npm] OIDC token exchange with the npm registry succeeded
```
But the actual `npm publish` in the publish step still failed with `ENEEDAUTH`. The reason: **Node 22 bundles npm 10.x**, and native OIDC trusted-publisher support in the npm CLI requires **npm ≥ 11.5.1**. The token exchange in `verifyConditions` verifies the OIDC context is reachable, but the publish itself delegates to the npm CLI, which was too old to use it.

## Fix
Add `npm install -g npm@latest` (currently 11.14.1) after `setup-node`, before `npm ci` and publish.

## Test plan
- [ ] Merge and verify the next push to `master` publishes successfully and the package appears on npm with a provenance attestation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)