### PR TITLE
fix: use Node 24 for publish instead of upgrading npm in place

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,11 +17,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          # https://nodered.org/docs/faq/node-versions#installing-nodejs
-          node-version: 22
-      # Node 22 bundles npm 10.x; native OIDC trusted-publisher
-      # support requires npm >= 11.5.1
-      - run: npm install -g npm@latest
+          # Node 24 bundles npm 11.x, required for native OIDC
+          # trusted-publisher support (npm >= 11.5.1)
+          node-version: 24
       - run: npm ci
       - run: npm test
       - run: npx semantic-release


### PR DESCRIPTION
## Root cause
`npm install -g npm@latest` (added in #404) fails with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` — npm corrupts its own module tree while upgrading itself in place. This is a well-known npm self-upgrade hazard.

## Fix
Skip the in-place upgrade entirely. **Node 24.15.0 bundles npm 11.12.1**, which already satisfies the `npm >= 11.5.1` requirement for native OIDC trusted publishing. Switch the publish job from Node 22 → Node 24 and remove the `npm install -g npm@latest` step. semantic-release v25 supports `>= 24.10.0`.

## Test plan
- [ ] Merge and verify the next push to `master` publishes successfully with a provenance attestation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)