### PR TITLE
fix: grant issues/PR write perms for @semantic-release/github

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,8 +11,10 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # semantic-release: create releases and push tags
-      id-token: write   # npm trusted publisher: OIDC token for npm auth
+      contents: write        # semantic-release: create releases and push tags
+      id-token: write        # npm trusted publisher: OIDC token for npm auth
+      issues: write          # @semantic-release/github: comment on resolved issues
+      pull-requests: write   # @semantic-release/github: comment on released PRs
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Progress
**npm publish via OIDC trusted publisher now works** — version 2.5.7 was published successfully (after #407 merged). 🎉

## Remaining failure
`@semantic-release/github` failed at the end of the run:
```
✘ An error occurred while running semantic-release:
RequestError [HttpError]: Resource not accessible by integration
status: 403  (POST .../issues#update-an-issue)
```
It posts "🎉 released in vX" comments on resolved issues / merged PRs, which needs `issues: write` and `pull-requests: write`. The job only had `contents` + `id-token`.

## Fix
Add `issues: write` and `pull-requests: write` to the publish job permissions.

## Note
The package itself **is published** — this only affected the post-release GitHub commenting. After this merges the whole pipeline (OIDC publish + provenance + GitHub release + issue comments) is green end to end, and the legacy `NPM_TOKEN` secret can be deleted.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)