### PR TITLE
ci: ignore unfixable transitive deps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,22 @@ updates:
   open-pull-requests-limit: 10
   reviewers:
   - raimondb
+  # These are transitive deps Dependabot cannot patch in this repo, so
+  # its security-update jobs fail on every run. The request-chain ones
+  # (form-data/qs/tough-cookie/ip-address) are locked by
+  # nefit-easy-commands -> request (deprecated, no newer release); the
+  # rest are bundled deep inside dev tooling (node-red/mocha/
+  # semantic-release). Real fix is upstream; ignore to stop the noise.
+  ignore:
+  - dependency-name: "form-data"
+  - dependency-name: "qs"
+  - dependency-name: "tough-cookie"
+  - dependency-name: "ip-address"
+  - dependency-name: "request"
+  - dependency-name: "glob"
+  - dependency-name: "js-yaml"
+  - dependency-name: "picomatch"
+  - dependency-name: "serialize-javascript"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
## Problem
The [Dependabot Updates](https://github.com/RaimondB/node-red-contrib-nefit-easy/actions/workflows/dependabot/dependabot-updates) workflow shows red on every run. The failing jobs are **security-only** updates for transitive deps Dependabot cannot patch in this repo:

| Dep | Why unfixable |
|---|---|
| form-data, qs, tough-cookie, ip-address | locked by `nefit-easy-commands → request` — `request` is deprecated, `nefit-easy-commands` has no release newer than 3.0.5 |
| glob, js-yaml, picomatch, serialize-javascript | bundled deep inside dev tooling (node-red / mocha / semantic-release) |

Dependabot reports `update_not_possible` / "latest possible version that can be installed is 2.3.3 because of conflicting dependencies" and the job errors out.

## Fix
Add `ignore` entries for these packages in the npm ecosystem so Dependabot stops attempting the impossible security updates. Regular version-update PRs (which succeed today) are unaffected.

## Note
This silences noise, not a real vulnerability fix — the underlying resolution is upstream (`nefit-easy-commands` dropping the deprecated `request`), which is outside our control and already documented in the project notes. `npm audit` will still report these.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)