### PR TITLE
ci: auto-merge official actions/ Dependabot PRs regardless of semver

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,9 @@
 # Auto-merges Dependabot PRs once branch-protection required checks pass:
-#  - any github-actions ecosystem update (trusted first-party actions;
-#    they are always tagged as major bumps, so a patch/minor gate would
-#    never let them through)
+#  - official GitHub actions (the `actions/` org only, e.g.
+#    actions/checkout, actions/setup-node) at any semver level; these
+#    are always tagged as major bumps so a patch/minor gate would never
+#    let them through. Third-party actions (dorny/*, dependabot/*) stay
+#    manual.
 #  - npm patch and minor updates
 # npm MAJOR bumps are left for manual review (a major can be a
 # breaking/ESM-only change, e.g. color-convert v3).
@@ -26,7 +28,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge
         if: >-
-          steps.meta.outputs.package-ecosystem == 'github_actions' ||
+          startsWith(steps.meta.outputs.dependency-names, 'actions/') ||
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,10 @@
-# Auto-merges Dependabot PRs for patch and minor updates once the
-# branch-protection required checks pass. Major version bumps are left
-# for manual review (a major can be a breaking/ESM-only change).
+# Auto-merges Dependabot PRs once branch-protection required checks pass:
+#  - any github-actions ecosystem update (trusted first-party actions;
+#    they are always tagged as major bumps, so a patch/minor gate would
+#    never let them through)
+#  - npm patch and minor updates
+# npm MAJOR bumps are left for manual review (a major can be a
+# breaking/ESM-only change, e.g. color-convert v3).
 
 name: Dependabot auto-merge
 
@@ -20,8 +24,9 @@ jobs:
         uses: dependabot/fetch-metadata@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for patch and minor updates
+      - name: Enable auto-merge
         if: >-
+          steps.meta.outputs.package-ecosystem == 'github_actions' ||
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Why
GitHub Actions are always tagged as major bumps (v4->v5->v6), so the patch/minor-only gate means action updates never auto-merge.

## Fix
Auto-merge when `dependency-names` starts with **`actions/`** (official GitHub `actions` org - actions/checkout, actions/setup-node, actions/upload-artifact) at any semver level, gated by branch-protection CI.

**Stays manual:** third-party actions (`dorny/test-reporter` #411, `dependabot/fetch-metadata`), npm majors (`color-convert@3`). npm patch/minor still auto-merge.

Existing open action PRs won't retroactively auto-merge; merge the `actions/*` ones manually once, then future ones flow automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)