### PR TITLE
chore: correct node/node-red version metadata for scorecard

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "easy"
   ],
   "node-red": {
-    "version": ">=2.0.0",
+    "version": ">=3.0.0",
     "nodes": {
       "nefit-easy": "nefit-easy.js",
       "nefit-easy-config": "nefit-easy-config.js"
     }
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.5"
   },
   "devDependencies": {
     "deep-extend": "^0.6.0",


### PR DESCRIPTION
Keeps the [flows.nodered.org scorecard](https://flows.nodered.org/node/node-red-contrib-nefit-easy2/scorecard) metadata accurate/current.

- `engines.node`: **`>=12.0.0` → `>=18.5`** — the old value was stale and inaccurate. node-red 4.1.10 (devDependency, and CI runs on Node 24) requires Node `>=18.5`; declaring `>=12` misrepresents what the package actually runs on.
- `node-red.version`: **`>=2.0.0` → `>=3.0.0`** — reflects the real supported range (node-red 4.1.10 needs Node ≥18.5; node-red 3.1 runs on ≥14). node-red 2.x targeted EOL Node and isn't a realistic support claim.

Note: the duplicate node names with the deprecated `node-red-contrib-nefit-easy` are intentional and don't affect the scorecard ("Node Uniqueness" is per-package and passes; the related-module line is informational).

Verified on Node 24.15.0: `npm ci` clean, 4/4 tests pass. Lockfile root metadata synced (also deduped two redundant nested `utf-8-validate` entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)